### PR TITLE
Utilise le scope user:email pour l'authent' GitHub

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -14,7 +14,7 @@ exports.githubAuthorize = function(req, res) {
 
   var authParams = qs.stringify({
     client_id: config.github.clientId,
-    scope: 'user'
+    scope: 'user:email'
   });
   // TODO: generate state to check after callback
 


### PR DESCRIPTION
Le scope `user` donne accès total en lecture **et écriture** au profil utilisateur, quand tout ce que le site veut c'est l'accès à l'adresse e-mail, qu'on peut obtenir avec le scope `user:email`.

Fixes #1 
