### PR TITLE
Change oAuth scope

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -14,7 +14,7 @@ exports.githubAuthorize = function(req, res) {
 
   var authParams = qs.stringify({
     client_id: config.github.clientId,
-    scope: 'user'
+    scope: 'user:email'
   });
   // TODO: generate state to check after callback
 


### PR DESCRIPTION
Ca me fait flipper les droits en écriture sur mes infos Github (cf https://twitter.com/chevreuil/statuses/456732821990547456)
Si vous voulez récupérer le mail le scope 'user.mail' devrait suffire.
